### PR TITLE
Add pyyaml to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ setup(
   include_package_data=True,
   install_requires=[
     'boto3 >= 1.10.0',
-    'botocore >= 1.13.0'
+    'botocore >= 1.13.0',
+    'pyyaml',
   ],
   entry_points={
     'console_scripts': [


### PR DESCRIPTION
After installing via `pip install cftdeploy`, the `cft-deploy` command fails with a `ModuleNotFoundError`:

```shell
❯ cft-deploy -m example.yaml
Traceback (most recent call last):
  File "/Users/patrick/.pyenv/versions/3.9.13/bin/cft-deploy", line 5, in <module>
    from cftdeploy import cft_deploy
  File "/Users/patrick/.pyenv/versions/3.9.13/lib/python3.9/site-packages/cftdeploy/__init__.py", line 1, in <module>
    from .manifest import *
  File "/Users/patrick/.pyenv/versions/3.9.13/lib/python3.9/site-packages/cftdeploy/manifest.py", line 1, in <module>
    from .template import *
  File "/Users/patrick/.pyenv/versions/3.9.13/lib/python3.9/site-packages/cftdeploy/template.py", line 7, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```

This PR adds `pyyaml` to `install_requires` so the yaml module will automatically be installed with `cftdeploy`.