### PR TITLE
Fix YAML key injection via unsanitized template metadata in generate_…

### DIFF
--- a/cftdeploy/template.py
+++ b/cftdeploy/template.py
@@ -115,11 +115,13 @@ class CFTemplate(object):
         parameter_string = ""
         for p in params['Parameters']:
             if 'Description' in p:
-                parameter_string += f"\n\n  # {p['Description']}"
+                sanitized_desc = str(p['Description']).replace('\n', ' ').replace('\r', ' ')
+                parameter_string += f"\n\n  # {sanitized_desc}"
             else:
                 parameter_string += f"\n\n  # No Description"
             if 'DefaultValue' in p:
-                parameter_string += f"\n  {p['ParameterKey']}: {p['DefaultValue']}"
+                sanitized_default = str(p['DefaultValue']).replace('\n', ' ').replace('\r', ' ')
+                parameter_string += f"\n  {p['ParameterKey']}: {sanitized_default}"
             else:
                 parameter_string += f"\n  {p['ParameterKey']}: "
 
@@ -133,7 +135,7 @@ class CFTemplate(object):
             'region': "CHANGEME"
         }
         if 'Description' in params:
-            manifest_values['template_description'] = params['Description']
+            manifest_values['template_description'] = str(params['Description']).replace('\n', ' ').replace('\r', ' ')
         else:
             manifest_values['template_description'] = "No Template Description Provided"
 


### PR DESCRIPTION
…manifest

Sanitize newline and carriage return characters from AWS validate_template() response fields (parameter Description, DefaultValue, and template-level Description) before interpolating them into the YAML manifest skeleton. Without this, attacker-controlled CloudFormation templates could inject arbitrary top-level YAML keys (e.g. LocalTemplate, S3Template) into generated manifests, enabling local file exfiltration or template substitution attacks.

https://claude.ai/code/session_01J22eeWbWwCpzbfp8QBYdhg